### PR TITLE
ENYO-773:  Add feedback feature to play feedback sound

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,0 +1,50 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+/**
+ * @namespace webOS.feedback
+ */
+
+webOS.feedback = {
+	/**
+	 * Play feedback sound
+	 * @param {string} param - feedback sound name
+	 */
+	play: function(param) {
+		if(webOS && webOS.platform && webOS.platform.wearable) {
+			var params = {
+				name: param || "touch",
+				sink: "pfeedback"
+			};
+
+			if(!window.PalmServiceBridge) {
+				return;
+			}
+
+			webOS.service.request("luna://com.palm.audio/systemsounds", {
+				method: "playFeedback",
+				parameters: params,
+				subscribe: false,
+				resubscribe: false
+			});
+		}
+	}
+};

--- a/src/platform.js
+++ b/src/platform.js
@@ -34,6 +34,9 @@ if(window.PalmSystem) {
  	*/
 	webOS.platform = {};
 	if((navigator.userAgent.indexOf("SmartTV")>-1) || (navigator.userAgent.indexOf("Large Screen")>-1)) {
+		// FIXME : Wearable device provides "Linux/SmartTV" string in navigator.userAgent incorrectly.
+		// Until fixing correctly, The only way to distinguish tv and wearable device is
+		// checking webOS.device.modelName value which would be "LGE Open webOS Device" for wearable device and "webOS.TV" for tv.
 		if(webOS.device.modelName === "LGE Open webOS Device") {
 			webOS.platform.wearable = true;
 		} else {

--- a/src/platform.js
+++ b/src/platform.js
@@ -34,7 +34,11 @@ if(window.PalmSystem) {
  	*/
 	webOS.platform = {};
 	if((navigator.userAgent.indexOf("SmartTV")>-1) || (navigator.userAgent.indexOf("Large Screen")>-1)) {
-		webOS.platform.tv = true;
+		if(webOS.device.modelName === "LGE Open webOS Device") {
+			webOS.platform.wearable = true;
+		} else {
+			webOS.platform.tv = true;
+		}
 	} else if(webOS.device.platformVersionMajor && webOS.device.platformVersionMinor) {
 		try {
 			var major = parseInt(webOS.device.platformVersionMajor);


### PR DESCRIPTION
Issue :  When tapping a button, an item or an icon button, we need feedback sound for wearable device.
Fix : Add webOS.platform.wearable to distinguish wearable device or not and add feedback feature to play feedback sound

https://jira2.lgsvl.com/browse/ENYO-773
Enyo-DCO-1.1-Signed-off-by: YB Sung <yb.sung@lge.com>