### PR TITLE
ENYO-967: To distinguish tv & watch, "SmartWatch" string in navigator.userAgent used

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -29,7 +29,7 @@ webOS.feedback = {
 	 * @param {string} param - feedback sound name
 	 */
 	play: function(param) {
-		if(webOS && webOS.platform && webOS.platform.wearable) {
+		if(webOS && webOS.platform && webOS.platform.watch) {
 			var params = {
 				name: param || "touch",
 				sink: "pfeedback"

--- a/src/platform.js
+++ b/src/platform.js
@@ -33,15 +33,10 @@ if(window.PalmSystem) {
 	 * @property {?boolean} legacy - Set true for legacy webOS 1.x-3.0.4
  	*/
 	webOS.platform = {};
-	if((navigator.userAgent.indexOf("SmartTV")>-1) || (navigator.userAgent.indexOf("Large Screen")>-1)) {
-		// FIXME : Wearable device provides "Linux/SmartTV" string in navigator.userAgent incorrectly.
-		// Until fixing correctly, The only way to distinguish tv and wearable device is
-		// checking webOS.device.modelName value which would be "LGE Open webOS Device" for wearable device and "webOS.TV" for tv.
-		if(webOS.device.modelName === "LGE Open webOS Device") {
-			webOS.platform.wearable = true;
-		} else {
-			webOS.platform.tv = true;
-		}
+	if(navigator.userAgent.indexOf("SmartWatch")>-1) {
+		webOS.platform.watch = true;
+	} else if((navigator.userAgent.indexOf("SmartTV")>-1) || (navigator.userAgent.indexOf("Large Screen")>-1)) {
+		webOS.platform.tv = true;
 	} else if(webOS.device.platformVersionMajor && webOS.device.platformVersionMinor) {
 		try {
 			var major = parseInt(webOS.device.platformVersionMajor);

--- a/src/voicereadout.js
+++ b/src/voicereadout.js
@@ -32,7 +32,7 @@ webOS.voicereadout = {
 	 * @param {string} s - String to voice readout.
 	 */
 	readAlert: function(s) {
-		if(webOS && webOS.platform && webOS.platform.wearable) {
+		if(webOS && webOS.platform && webOS.platform.watch) {
 
 			/**
 			* Check VoiceReadOut talkback is enabled or not.


### PR DESCRIPTION
Issue
1) To distinguish tv & watch, we used webOS.device.modelName variable which was "LGE Open webOS Device" in watch. But these days the value for it was modified to "LG Electronics" and "SmartWatch" string was added in navigator.userAgent.
2) "wearable" variable name is too broad and it's better to use "watch" because "SmartWatch" string was added in navigator.userAgent

Fix
1) We want to use navigator.userAgent instead of using webOS.device.modelName like the TV condition below
```
if((navigator.userAgent.indexOf("SmartTV")>-1) || (navigator.userAgent.indexOf("Large Screen")>-1))
```
So the condition for watch would be
```
if(navigator.userAgent.indexOf("SmartWatch")>-1) {
```
2) We renamed "webOS.platform.wearable" to "webOS.platform.watch".

https://jira2.lgsvl.com/browse/ENYO-967
https://jira2.lgsvl.com/browse/DRD-2828
Enyo-DCO-1.1-Signed-off-by: YB Sung <yb.sung@lge.com>