### PR TITLE
ENYO-1126: Accessibility: Add "readAlert()" to enyo

### DIFF
--- a/src/voicereadout.js
+++ b/src/voicereadout.js
@@ -111,6 +111,44 @@ webOS.voicereadout = {
 					getSpeechRate(readAlertMessage);
 				});
 			});
+		} else if (webOS && webOS.platform && webOS.platform.tv) {
+
+			/**
+			* Check AudioGuidance is enabled or not.
+			*
+			* @private
+			*/
+			var checkAudioGuidance = function(callback) {
+				webOS.service.request("luna://com.webos.settingsservice", {
+					method: "getSystemSettings",
+					parameters: {"keys" : ["audioGuidance"],"category": "option"},
+					onSuccess: function(inResponse) {
+						if (inResponse && inResponse.settings.audioGuidance === "on") {
+							callback();
+						}
+					},
+					onFailure: function(inError) {
+						console.error("Failed to get system AudioGuidance settings: " + JSON.stringify(inError));
+					}
+				});
+			};
+
+			/**
+			* Read alert message using TTS api.
+			*
+			* @private
+			*/
+			var readAlertMessage = function() {
+				webOS.service.request("luna://com.webos.service.tts", {
+					method: "speak",
+					parameters: {"text":s, "clear": true},
+					onFailure: function(inError) {
+						console.error("Failed to readAlertMessage: " + JSON.stringify(inError));
+					}
+				});
+			};
+
+			checkAudioGuidance(readAlertMessage);
 		}
 	}
 };

--- a/src/voicereadout.js
+++ b/src/voicereadout.js
@@ -149,6 +149,8 @@ webOS.voicereadout = {
 			};
 
 			checkAudioGuidance(readAlertMessage);
+		} else {
+			console.warn("Platform doesn't support TTS api.");
 		}
 	}
 };


### PR DESCRIPTION
The readAlert API is for calling tts api of system service. Most of
cases accessibility supports focus based readout, but ux scenario
sometimes wants application reads a message dynamically. We provides the
readAlert API to cover it.
Added the code calling TTS api of webOS TV in webOS.js

https://jira2.lgsvl.com/browse/ENYO-1126
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>