### PR TITLE
ENYO-3327: Add clear parameter to readAlert()

### DIFF
--- a/src/voicereadout.js
+++ b/src/voicereadout.js
@@ -27,7 +27,7 @@ webOS.voicereadout = {
 	 * @param {boolean} c - Clear optoin for TTS. If true it will cut off previous reading. Valid for TV only
 	 */
 	readAlert: function(s, c) {
-		var clear = (c === undefined)? true : c;
+		var clear = (typeof c === 'boolean')? c : true;
 
 		if(webOS && webOS.platform && webOS.platform.watch) {
 

--- a/src/voicereadout.js
+++ b/src/voicereadout.js
@@ -24,8 +24,11 @@ webOS.voicereadout = {
 	/**
 	 * Read alert text when accessibility VoiceReadout enabled.
 	 * @param {string} s - String to voice readout.
+	 * @param {boolean} c - Clear optoin for TTS. If true it will cut off previous reading. Valid for TV only
 	 */
-	readAlert: function(s) {
+	readAlert: function(s, c) {
+		var clear = (c === undefined)? true : c;
+
 		if(webOS && webOS.platform && webOS.platform.watch) {
 
 			var locale, speechRate;
@@ -135,7 +138,7 @@ webOS.voicereadout = {
 			var readAlertMessage = function() {
 				webOS.service.request("luna://com.webos.service.tts", {
 					method: "speak",
-					parameters: {"text":s, "clear": true},
+					parameters: {"text":s, "clear": clear},
 					onFailure: function(inError) {
 						console.error("Failed to readAlertMessage: " + JSON.stringify(inError));
 					}


### PR DESCRIPTION
Description
---
As of now enyo supports readalert() API with clear param always true. App needs to call TTS with clear param false so that won't cut off reading

Enyo-DCO-1.1-Signed-off-by: Seungho Park <seunghoh.park@lge.com>